### PR TITLE
Fix SMTP SSL configuration for AWS SES

### DIFF
--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -25,5 +25,6 @@ data:
   N8N_EMAIL_MODE: "smtp"
   N8N_SMTP_HOST: "email-smtp.us-west-2.amazonaws.com"  # Change to your SES region
   N8N_SMTP_PORT: "587"
-  N8N_SMTP_SSL: "true"
+  N8N_SMTP_SSL: "false"
+  N8N_SMTP_STARTTLS: "true"
   N8N_DEFAULT_EMAIL: "paul@paulbonneville.com"  # Verified email address


### PR DESCRIPTION
## Issue
Password reset emails were failing with SSL version mismatch error:
`28A2D280597E0000:error:0A00010B:SSL routines:ssl3_get_record:wrong version number`

## Root Cause
AWS SES on port 587 requires STARTTLS (explicit TLS) rather than direct SSL connection.

## Fix
- Changed `N8N_SMTP_SSL` from `true` to `false`
- Added `N8N_SMTP_STARTTLS: true` for proper TLS upgrade

## Testing
After deployment, password reset emails should work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)